### PR TITLE
Set aggregate_data as a constant

### DIFF
--- a/afang/strategies/analyzer.py
+++ b/afang/strategies/analyzer.py
@@ -8,8 +8,11 @@ from afang.strategies.models import TradePosition
 from afang.utils.function_group import FunctionGroup
 
 logger = logging.getLogger(__name__)
-
 function_group = FunctionGroup()
+
+# symbol name given to the first entry of `StrategyAnalyzer.analysis_results`
+# that is derived from a sorted trade sequence of all traded symbols.
+AGGREGATE_DATA = "AGGREGATE_DATA"
 
 
 class StrategyAnalyzer:
@@ -1093,7 +1096,7 @@ class StrategyAnalyzer:
                 {"symbol": symbol, "trades": list(symbol_trades.values())}
             )
         self.analysis_results.insert(
-            0, {"symbol": "AGGREGATE_DATA", "trades": sorted_aggregate_trades}
+            0, {"symbol": AGGREGATE_DATA, "trades": sorted_aggregate_trades}
         )
 
         # Compute strategy performance analysis.

--- a/tests/strategies/analyzer_test.py
+++ b/tests/strategies/analyzer_test.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from afang.strategies.analyzer import StrategyAnalyzer
+from afang.strategies.analyzer import AGGREGATE_DATA, StrategyAnalyzer
 from afang.strategies.models import TradePosition
 
 
@@ -722,7 +722,7 @@ def test_run_analysis(dummy_strategy_analyzer) -> None:
     analysis_results = dummy_strategy_analyzer.analysis_results
 
     assert len(analysis_results) == 2
-    assert dummy_strategy_analyzer.analysis_results[0]["symbol"] == "AGGREGATE_DATA"
+    assert dummy_strategy_analyzer.analysis_results[0]["symbol"] == AGGREGATE_DATA
     assert dummy_strategy_analyzer.analysis_results[1]["symbol"] == "test_symbol"
     assert (
         list(dummy_strategy_analyzer.analysis_results[0].keys())


### PR DESCRIPTION
This PR sets the `AGGREGATE_DATA` string to be a constant to allow for loose coupling.