### PR TITLE
Set dydx candle opentime to int

### DIFF
--- a/afang/exchanges/binance.py
+++ b/afang/exchanges/binance.py
@@ -88,7 +88,7 @@ class BinanceExchange(IsExchange):
         for candle in raw_candles:
             candles.append(
                 Candle(
-                    open_time=float(candle[0]),
+                    open_time=int(candle[0]),
                     open=float(candle[1]),
                     high=float(candle[2]),
                     low=float(candle[3]),

--- a/afang/exchanges/dydx.py
+++ b/afang/exchanges/dydx.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from typing import Dict, List, Optional
 
-import dateutil.parser as dp
+import dateutil.parser
 import pytz
 
 from afang.exchanges.is_exchange import IsExchange
@@ -109,7 +109,9 @@ class DyDxExchange(IsExchange):
         for candle in raw_candles:
             candles.append(
                 Candle(
-                    open_time=float(dp.parse(candle["startedAt"]).timestamp() * 1000),
+                    open_time=int(
+                        dateutil.parser.isoparse(candle["startedAt"]).timestamp() * 1000
+                    ),
                     open=float(candle["open"]),
                     high=float(candle["high"]),
                     low=float(candle["low"]),

--- a/afang/exchanges/models.py
+++ b/afang/exchanges/models.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 @dataclass
 class Candle:
-    open_time: float
+    open_time: int
     open: float
     high: float
     low: float

--- a/tests/exchanges/dydx_test.py
+++ b/tests/exchanges/dydx_test.py
@@ -103,7 +103,7 @@ def test_get_symbols(mocker, req_response, expected_symbols) -> None:
                 ]
             },
             [
-                Candle(1578182400000.0, 1.0, 2.0, 3.0, 4.0, 5.0),
+                Candle(1578182400000, 1.0, 2.0, 3.0, 4.0, 5.0),
                 Candle(1609804800000, 10.0, 11.0, 12.0, 13.0, 14.0),
             ],
         ),


### PR DESCRIPTION
### Description

This PR updates the candle opentime of `dydx` to be an `int` rather than a `float`.

### Changelog

- set dydx opentime to int rather than float.
- update dydx opentime conversion to use dateutil `isoparse` rather than `parse`.

### Checklist

- [x] This change has been unit tested.
