### PR TITLE
Support multiple HTTP methods xchange make request

### DIFF
--- a/afang/exchanges/binance.py
+++ b/afang/exchanges/binance.py
@@ -2,7 +2,7 @@ import logging
 from typing import Dict, List, Optional
 
 from afang.exchanges.is_exchange import IsExchange
-from afang.exchanges.models import Candle
+from afang.exchanges.models import Candle, HTTPMethod
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class BinanceExchange(IsExchange):
         params: Dict = dict()
         endpoint = "/fapi/v1/exchangeInfo"
 
-        data = self._make_request(endpoint, params)
+        data = self._make_request(HTTPMethod.GET, endpoint, params)
         if data is None:
             return symbols
 
@@ -80,7 +80,7 @@ class BinanceExchange(IsExchange):
 
         endpoint = "/fapi/v1/klines"
 
-        raw_candles = self._make_request(endpoint, params)
+        raw_candles = self._make_request(HTTPMethod.GET, endpoint, params)
         if raw_candles is None:
             return None
 

--- a/afang/exchanges/dydx.py
+++ b/afang/exchanges/dydx.py
@@ -6,7 +6,7 @@ import dateutil.parser
 import pytz
 
 from afang.exchanges.is_exchange import IsExchange
-from afang.exchanges.models import Candle
+from afang.exchanges.models import Candle, HTTPMethod
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class DyDxExchange(IsExchange):
         params: Dict = dict()
         endpoint = "/v3/markets"
 
-        data = self._make_request(endpoint, params)
+        data = self._make_request(HTTPMethod.GET, endpoint, params)
         if data is None:
             return symbols
 
@@ -96,7 +96,7 @@ class DyDxExchange(IsExchange):
 
         endpoint = f"/v3/candles/{symbol}"
 
-        raw_candles = self._make_request(endpoint, params)
+        raw_candles = self._make_request(HTTPMethod.GET, endpoint, params)
         if raw_candles is None:
             return None
 

--- a/afang/exchanges/models.py
+++ b/afang/exchanges/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 
 
 @dataclass
@@ -9,3 +10,9 @@ class Candle:
     low: float
     close: float
     volume: float
+
+
+class HTTPMethod(Enum):
+    GET = "GET"
+    POST = "POST"
+    DELETE = "DELETE"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 
 from afang.exchanges.is_exchange import IsExchange
-from afang.exchanges.models import Candle
+from afang.exchanges.models import Candle, HTTPMethod
 from afang.strategies.is_strategy import IsStrategy
 from afang.strategies.models import TradeLevels
 from afang.strategies.optimizer import StrategyOptimizer
@@ -69,8 +69,10 @@ def dummy_is_exchange() -> IsExchange:
         def _get_symbols(self) -> List[str]:
             return super()._get_symbols()
 
-        def _make_request(self, endpoint: str, query_parameters: Dict) -> Any:
-            return super()._make_request(endpoint, query_parameters)
+        def _make_request(
+            self, method: HTTPMethod, endpoint: str, query_parameters: Dict
+        ) -> Any:
+            return super()._make_request(method, endpoint, query_parameters)
 
         def get_historical_data(
             self,

--- a/tests/exchanges/binance_test.py
+++ b/tests/exchanges/binance_test.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import pytest
 
 from afang.exchanges.binance import BinanceExchange
-from afang.exchanges.models import Candle
+from afang.exchanges.models import Candle, HTTPMethod
 
 
 def test_binance_exchange_init(mocker) -> None:
@@ -53,7 +53,9 @@ def test_binance_exchange_init(mocker) -> None:
 )
 def test_get_symbols(mocker, req_response, expected_symbols) -> None:
     # mock the return value of the _make_request function.
-    def mock_make_request(_self, _endpoint: str, _query_parameters: Dict) -> Any:
+    def mock_make_request(
+        _self, _method: HTTPMethod, _endpoint: str, _query_parameters: Dict
+    ) -> Any:
         return req_response
 
     mocker.patch(
@@ -118,7 +120,9 @@ def test_get_historical_data(mocker, req_response, expected_candles) -> None:
     )
 
     # mock the return value of the _make_request function.
-    def mock_make_request(_self, _endpoint: str, _query_parameters: Dict) -> Any:
+    def mock_make_request(
+        _self, _method: HTTPMethod, _endpoint: str, _query_parameters: Dict
+    ) -> Any:
         return req_response
 
     mocker.patch(

--- a/tests/exchanges/dydx_test.py
+++ b/tests/exchanges/dydx_test.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 import pytest
 
 from afang.exchanges.dydx import DyDxExchange
-from afang.exchanges.models import Candle
+from afang.exchanges.models import Candle, HTTPMethod
 
 
 def test_dydx_exchange_init(mocker) -> None:
@@ -54,7 +54,9 @@ def test_dydx_exchange_init(mocker) -> None:
 )
 def test_get_symbols(mocker, req_response, expected_symbols) -> None:
     # mock the return value of the _make_request function.
-    def mock_make_request(_self, _endpoint: str, _query_parameters: Dict) -> Any:
+    def mock_make_request(
+        _self, _method: HTTPMethod, _endpoint: str, _query_parameters: Dict
+    ) -> Any:
         return req_response
 
     mocker.patch(
@@ -122,7 +124,9 @@ def test_get_historical_data(mocker, req_response, expected_candles) -> None:
     )
 
     # mock the return value of the _make_request function.
-    def mock_make_request(_self, _endpoint: str, _query_parameters: Dict) -> Any:
+    def mock_make_request(
+        _self, _method: HTTPMethod, _endpoint: str, _query_parameters: Dict
+    ) -> Any:
         return req_response
 
     mocker.patch(

--- a/tests/exchanges/is_exchange_test.py
+++ b/tests/exchanges/is_exchange_test.py
@@ -1,6 +1,8 @@
 import pytest
 import requests
 
+from afang.exchanges.models import HTTPMethod
+
 
 def test_is_exchange_initialization(dummy_is_exchange) -> None:
     assert dummy_is_exchange.name == "test_exchange"
@@ -36,7 +38,7 @@ def test_is_exchange_make_request(
             exc=exception,
         )
     response = dummy_is_exchange._make_request(
-        "/endpoint", query_parameters={"query": "bull", "limit": "dog"}
+        HTTPMethod.GET, "/endpoint", query_parameters={"query": "bull", "limit": "dog"}
     )
 
     assert response == expected_response


### PR DESCRIPTION
### Description

This PR adds support for exchanges to make requests using either `GET`, `POST`, or `DELETE` HTTP methods.

### Changelog

- Add HTTP method param in `is_exchange` `_make_request` function.

### Checklist

- [x] This change has been unit tested.
