### PR TITLE
Add timeframe param get historical candles

### DIFF
--- a/afang/database/backtest_data_collector.py
+++ b/afang/database/backtest_data_collector.py
@@ -27,7 +27,7 @@ def fetch_initial_data(
     :return: Union[Tuple[None, None], Tuple[float, float]]
     """
 
-    data = exchange.get_historical_data(symbol, end_time=int(time.time() * 1000))
+    data = exchange.get_historical_candles(symbol, end_time=int(time.time() * 1000))
 
     if data is None:
         logger.warning(
@@ -83,7 +83,7 @@ def fetch_most_recent_data(
     _most_recent_timestamp = most_recent_timestamp
 
     while True:
-        data = exchange.get_historical_data(
+        data = exchange.get_historical_candles(
             symbol, start_time=int(_most_recent_timestamp)
         )
         data = sorted(data, key=attrgetter("open_time"))
@@ -158,7 +158,7 @@ def fetch_older_data(
     _oldest_timestamp = oldest_timestamp
 
     while True:
-        data = exchange.get_historical_data(symbol, end_time=int(_oldest_timestamp))
+        data = exchange.get_historical_candles(symbol, end_time=int(_oldest_timestamp))
         data = sorted(data, key=attrgetter("open_time"))
 
         if data is None:

--- a/afang/exchanges/binance.py
+++ b/afang/exchanges/binance.py
@@ -1,10 +1,23 @@
 import logging
+from enum import Enum
 from typing import Dict, List, Optional
 
 from afang.exchanges.is_exchange import IsExchange
 from afang.exchanges.models import Candle, HTTPMethod
+from afang.models import Timeframe
 
 logger = logging.getLogger(__name__)
+
+
+class TimeframeMapping(Enum):
+    M1 = "1m"
+    M5 = "5m"
+    M15 = "15m"
+    M30 = "30m"
+    H1 = "1h"
+    H4 = "4h"
+    H12 = "12h"
+    D1 = "1d"
 
 
 class BinanceExchange(IsExchange):
@@ -50,6 +63,7 @@ class BinanceExchange(IsExchange):
         symbol: str,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
+        timeframe: Optional[Timeframe] = Timeframe.M1,
     ) -> Optional[List[Candle]]:
         """Fetch candlestick bars for a particular symbol from the Binance
         exchange. If start_time and end_time are not sent, the most recent
@@ -58,13 +72,24 @@ class BinanceExchange(IsExchange):
         :param symbol: symbol to fetch historical candlestick bars for.
         :param start_time: optional. the start time to begin fetching candlestick bars as a UNIX timestamp in ms.
         :param end_time: optional. the end time to begin fetching candlestick bars as a UNIX timestamp in ms.
+        :param timeframe: optional. timeframe to download historical candles.
 
         :return: Optional[List[Candle]]
         """
 
+        try:
+            tf_interval: str = TimeframeMapping[timeframe.name].value
+        except KeyError:
+            logger.error(
+                "%s cannot fetch historical candles in %s intervals. Please use another timeframe.",
+                self.name,
+                timeframe.value,
+            )
+            return None
+
         params: Dict = dict()
         params["symbol"] = symbol
-        params["interval"] = "1m"
+        params["interval"] = tf_interval
         params["limit"] = "1500"
 
         if start_time:

--- a/afang/exchanges/binance.py
+++ b/afang/exchanges/binance.py
@@ -45,7 +45,7 @@ class BinanceExchange(IsExchange):
 
         return symbols
 
-    def get_historical_data(
+    def get_historical_candles(
         self,
         symbol: str,
         start_time: Optional[int] = None,

--- a/afang/exchanges/binance.py
+++ b/afang/exchanges/binance.py
@@ -81,7 +81,7 @@ class BinanceExchange(IsExchange):
             tf_interval: str = TimeframeMapping[timeframe.name].value
         except KeyError:
             logger.error(
-                "%s cannot fetch historical candles in %s intervals. Please use another timeframe.",
+                "%s cannot fetch historical candles in %s intervals. Please use another timeframe",
                 self.name,
                 timeframe.value,
             )

--- a/afang/exchanges/dydx.py
+++ b/afang/exchanges/dydx.py
@@ -90,7 +90,7 @@ class DyDxExchange(IsExchange):
             tf_interval: str = TimeframeMapping[timeframe.name].value
         except KeyError:
             logger.error(
-                "%s cannot fetch historical candles in %s intervals. Please use another timeframe.",
+                "%s cannot fetch historical candles in %s intervals. Please use another timeframe",
                 self.name,
                 timeframe.value,
             )

--- a/afang/exchanges/dydx.py
+++ b/afang/exchanges/dydx.py
@@ -55,7 +55,7 @@ class DyDxExchange(IsExchange):
 
         return symbols
 
-    def get_historical_data(
+    def get_historical_candles(
         self,
         symbol: str,
         start_time: Optional[int] = None,

--- a/afang/exchanges/dydx.py
+++ b/afang/exchanges/dydx.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from enum import Enum
 from typing import Dict, List, Optional
 
 import dateutil.parser
@@ -7,8 +8,19 @@ import pytz
 
 from afang.exchanges.is_exchange import IsExchange
 from afang.exchanges.models import Candle, HTTPMethod
+from afang.models import Timeframe
 
 logger = logging.getLogger(__name__)
+
+
+class TimeframeMapping(Enum):
+    M1 = "1MIN"
+    M5 = "5MINS"
+    M15 = "15MINS"
+    M30 = "30MINS"
+    H1 = "1HOUR"
+    H4 = "4HOURS"
+    D1 = "1DAY"
 
 
 class DyDxExchange(IsExchange):
@@ -60,6 +72,7 @@ class DyDxExchange(IsExchange):
         symbol: str,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
+        timeframe: Optional[Timeframe] = Timeframe.M1,
     ) -> Optional[List[Candle]]:
         """Fetch candlestick bars for a particular symbol from the DyDx
         exchange. If start_time and end_time are not sent, the most recent
@@ -68,14 +81,25 @@ class DyDxExchange(IsExchange):
         :param symbol: symbol to fetch historical candlestick bars for.
         :param start_time: optional. the start time to begin fetching candlestick bars as a UNIX timestamp in ms.
         :param end_time: optional. the end time to begin fetching candlestick bars as a UNIX timestamp in ms.
+        :param timeframe: optional. timeframe to download historical candles.
 
         :return: Optional[List[Candle]]
         """
 
+        try:
+            tf_interval: str = TimeframeMapping[timeframe.name].value
+        except KeyError:
+            logger.error(
+                "%s cannot fetch historical candles in %s intervals. Please use another timeframe.",
+                self.name,
+                timeframe.value,
+            )
+            return None
+
         candle_fetch_limit = 100
 
         params = dict()
-        params["resolution"] = "1MIN"
+        params["resolution"] = tf_interval
         params["limit"] = str(candle_fetch_limit)
 
         timezone = pytz.UTC

--- a/afang/exchanges/is_exchange.py
+++ b/afang/exchanges/is_exchange.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 import requests
 
 from afang.exchanges.models import Candle, HTTPMethod
+from afang.models import Timeframe
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +100,7 @@ class IsExchange(ABC):
         symbol: str,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
+        timeframe: Optional[Timeframe] = Timeframe.M1,
     ) -> Optional[List[Candle]]:
         """Fetch candlestick bars for a particular symbol from the exchange. If
         start_time and end_time are not provided, the most recent klines are
@@ -107,6 +109,7 @@ class IsExchange(ABC):
         :param symbol: symbol to fetch historical candlestick bars for.
         :param start_time: optional. the start time to begin fetching candlestick bars as a UNIX timestamp in ms.
         :param end_time: optional. the end time to begin fetching candlestick bars as a UNIX timestamp in ms.
+        :param timeframe: optional. timeframe to download historical candles.
 
         :return: Optional[List[Candle]]
         """

--- a/afang/exchanges/is_exchange.py
+++ b/afang/exchanges/is_exchange.py
@@ -94,7 +94,7 @@ class IsExchange(ABC):
         return None
 
     @abstractmethod
-    def get_historical_data(
+    def get_historical_candles(
         self,
         symbol: str,
         start_time: Optional[int] = None,

--- a/afang/models.py
+++ b/afang/models.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 class Timeframe(Enum):
     M1 = "1m"
+    M3 = "3m"
     M5 = "5m"
     M15 = "15m"
     M30 = "30m"

--- a/afang/models.py
+++ b/afang/models.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class Timeframe(Enum):
+    M1 = "1m"
+    M5 = "5m"
+    M15 = "15m"
+    M30 = "30m"
+    H1 = "1h"
+    H4 = "4h"
+    H12 = "12h"
+    D1 = "1d"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,13 +74,13 @@ def dummy_is_exchange() -> IsExchange:
         ) -> Any:
             return super()._make_request(method, endpoint, query_parameters)
 
-        def get_historical_data(
+        def get_historical_candles(
             self,
             symbol: str,
             start_time: Optional[int] = None,
             end_time: Optional[int] = None,
         ) -> Optional[List[Candle]]:
-            return super().get_historical_data(symbol, start_time, end_time)
+            return super().get_historical_candles(symbol, start_time, end_time)
 
     return Dummy(name="test_exchange", base_url="https://dummy.com")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import pytest
 
 from afang.exchanges.is_exchange import IsExchange
 from afang.exchanges.models import Candle, HTTPMethod
+from afang.models import Timeframe
 from afang.strategies.is_strategy import IsStrategy
 from afang.strategies.models import TradeLevels
 from afang.strategies.optimizer import StrategyOptimizer
@@ -79,8 +80,11 @@ def dummy_is_exchange() -> IsExchange:
             symbol: str,
             start_time: Optional[int] = None,
             end_time: Optional[int] = None,
+            timeframe: Optional[Timeframe] = Timeframe.M1,
         ) -> Optional[List[Candle]]:
-            return super().get_historical_candles(symbol, start_time, end_time)
+            return super().get_historical_candles(
+                symbol, start_time, end_time, timeframe
+            )
 
     return Dummy(name="test_exchange", base_url="https://dummy.com")
 

--- a/tests/database/backtest_data_collector_test.py
+++ b/tests/database/backtest_data_collector_test.py
@@ -34,9 +34,9 @@ from afang.exchanges.models import Candle
 def test_fetch_initial_data(
     mocker, dummy_is_exchange, ohlcv_root_db_dir, historical_data, expected_return_value
 ) -> None:
-    # mock the get_historical_data function
+    # mock the get_historical_candles function
     mocked_get_historical_data = mocker.patch(
-        "afang.database.backtest_data_collector.IsExchange.get_historical_data"
+        "afang.database.backtest_data_collector.IsExchange.get_historical_candles"
     )
     mocked_get_historical_data.return_value = historical_data
 
@@ -72,9 +72,9 @@ def test_fetch_initial_data(
 def test_fetch_most_recent_data(
     mocker, dummy_is_exchange, ohlcv_root_db_dir, historical_data, expected_return_value
 ) -> None:
-    # mock the get_historical_data function
+    # mock the get_historical_candles function
     mocked_get_historical_data = mocker.patch(
-        "afang.database.backtest_data_collector.IsExchange.get_historical_data"
+        "afang.database.backtest_data_collector.IsExchange.get_historical_candles"
     )
     mocked_get_historical_data.return_value = historical_data
 
@@ -112,9 +112,9 @@ def test_fetch_most_recent_data(
 def test_fetch_older_data(
     mocker, dummy_is_exchange, ohlcv_root_db_dir, historical_data, expected_return_value
 ) -> None:
-    # mock the get_historical_data function
+    # mock the get_historical_candles function
     mocked_get_historical_data = mocker.patch(
-        "afang.database.backtest_data_collector.IsExchange.get_historical_data"
+        "afang.database.backtest_data_collector.IsExchange.get_historical_candles"
     )
     mocked_get_historical_data.return_value = historical_data
 

--- a/tests/exchanges/binance_test.py
+++ b/tests/exchanges/binance_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from afang.exchanges.binance import BinanceExchange
 from afang.exchanges.models import Candle, HTTPMethod
+from afang.models import Timeframe
 
 
 def test_binance_exchange_init(mocker) -> None:
@@ -134,4 +135,24 @@ def test_get_historical_candles(mocker, req_response, expected_candles) -> None:
     assert (
         binance_exchange.get_historical_candles("test_symbol", 2, 100)
         == expected_candles
+    )
+
+
+def test_get_historical_candles_unknown_timeframe(mocker, caplog) -> None:
+    # mock the return value of the _get_symbols function.
+    def mock_get_symbols(_self):
+        return ["test_symbol"]
+
+    mocker.patch(
+        "afang.exchanges.binance.BinanceExchange._get_symbols",
+        mock_get_symbols,
+    )
+
+    binance_exchange = BinanceExchange()
+    binance_exchange.get_historical_candles("test_symbol", 2, 100, Timeframe.M3)
+
+    assert caplog.records[0].levelname == "ERROR"
+    assert (
+        "binance cannot fetch historical candles in 3m intervals. Please use another timeframe"
+        in caplog.text
     )

--- a/tests/exchanges/binance_test.py
+++ b/tests/exchanges/binance_test.py
@@ -132,5 +132,6 @@ def test_get_historical_data(mocker, req_response, expected_candles) -> None:
 
     binance_exchange = BinanceExchange()
     assert (
-        binance_exchange.get_historical_data("test_symbol", 2, 100) == expected_candles
+        binance_exchange.get_historical_candles("test_symbol", 2, 100)
+        == expected_candles
     )

--- a/tests/exchanges/binance_test.py
+++ b/tests/exchanges/binance_test.py
@@ -109,7 +109,7 @@ def test_get_symbols(mocker, req_response, expected_symbols) -> None:
         (None, None),
     ],
 )
-def test_get_historical_data(mocker, req_response, expected_candles) -> None:
+def test_get_historical_candles(mocker, req_response, expected_candles) -> None:
     # mock the return value of the _get_symbols function.
     def mock_get_symbols(_self):
         return ["test_symbol"]

--- a/tests/exchanges/dydx_test.py
+++ b/tests/exchanges/dydx_test.py
@@ -135,4 +135,6 @@ def test_get_historical_data(mocker, req_response, expected_candles) -> None:
     )
 
     dydx_exchange = DyDxExchange()
-    assert dydx_exchange.get_historical_data("test_symbol", 2, 100) == expected_candles
+    assert (
+        dydx_exchange.get_historical_candles("test_symbol", 2, 100) == expected_candles
+    )

--- a/tests/exchanges/dydx_test.py
+++ b/tests/exchanges/dydx_test.py
@@ -113,7 +113,7 @@ def test_get_symbols(mocker, req_response, expected_symbols) -> None:
         ({}, None),
     ],
 )
-def test_get_historical_data(mocker, req_response, expected_candles) -> None:
+def test_get_historical_candles(mocker, req_response, expected_candles) -> None:
     # mock the return value of the _get_symbols function.
     def mock_get_symbols(_self):
         return ["test_symbol"]

--- a/tests/exchanges/is_exchange_test.py
+++ b/tests/exchanges/is_exchange_test.py
@@ -10,7 +10,7 @@ def test_is_exchange_initialization(dummy_is_exchange) -> None:
     assert dummy_is_exchange.name == "test_exchange"
     assert dummy_is_exchange._base_url == "https://dummy.com"
     assert dummy_is_exchange.symbols == list()
-    assert dummy_is_exchange.get_historical_data("test_symbol", 0, 100) is None
+    assert dummy_is_exchange.get_historical_candles("test_symbol", 0, 100) is None
     assert dummy_is_exchange.get_config_params() == {
         "query_limit": 1,
         "write_limit": 50000,


### PR DESCRIPTION
### Description

Add `timeframe` param to `get_historical_candles` function that accepts an exchange agnostic `timeframe` enum.

### Changelog

- Added an exchange agnostic `Timeframe` enum for data fetching and resampling.
- Added a `timeframe` param to `get_historical_candles` function.

### Checklist

- [x] This change has been unit tested.
