### PR TITLE
Add testnet functionality

### DIFF
--- a/afang/cli_handler.py
+++ b/afang/cli_handler.py
@@ -30,6 +30,8 @@ def parse_args(args) -> argparse.Namespace:
     parser.add_argument(
         "--testnet",
         type=bool,
+        action=argparse.BooleanOptionalAction,
+        default=False,
         help="whether to use the testnet version of the exchange",
     )
     parser.add_argument(

--- a/afang/cli_handler.py
+++ b/afang/cli_handler.py
@@ -28,6 +28,11 @@ def parse_args(args) -> argparse.Namespace:
         required=True,
     )
     parser.add_argument(
+        "--testnet",
+        type=bool,
+        help="whether to use the testnet version of the exchange",
+    )
+    parser.add_argument(
         "--symbols",
         type=str,
         nargs="+",

--- a/afang/database/backtest_data_collector.py
+++ b/afang/database/backtest_data_collector.py
@@ -233,7 +233,7 @@ def fetch_symbol_data(
         )
         return None
 
-    ohlcv_db = OHLCVDatabase(exchange.name, symbol, root_db_dir)
+    ohlcv_db = OHLCVDatabase(exchange, symbol, root_db_dir)
     ohlcv_db.create_dataset(symbol)
 
     oldest_timestamp, most_recent_timestamp = ohlcv_db.get_min_max_timestamp(symbol)

--- a/afang/database/ohlcv_database.py
+++ b/afang/database/ohlcv_database.py
@@ -9,6 +9,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
+from afang.exchanges import IsExchange
 from afang.exchanges.models import Candle
 
 logger = logging.getLogger(__name__)
@@ -19,7 +20,7 @@ class OHLCVDatabase:
     database."""
 
     def __init__(
-        self, exchange: str, symbol: str, root_db_dir: Optional[str] = None
+        self, exchange: IsExchange, symbol: str, root_db_dir: Optional[str] = None
     ) -> None:
         """Initialize the OHLCVDatabase class.
 
@@ -32,7 +33,10 @@ class OHLCVDatabase:
             root_db_dir = f"{pathlib.Path(__file__).parents[2]}/data/ohlcv"
 
         # Create exchange database directory if it does not exist.
-        exchange_db_dir = f"{root_db_dir}/{exchange}"
+        exchange_db_dir = f"{root_db_dir}/{exchange.name}"
+        if exchange.testnet:
+            exchange_db_dir += "-testnet"
+
         if not os.path.exists(exchange_db_dir):
             os.mkdir(exchange_db_dir)
 

--- a/afang/exchanges/binance.py
+++ b/afang/exchanges/binance.py
@@ -23,11 +23,17 @@ class TimeframeMapping(Enum):
 class BinanceExchange(IsExchange):
     """Interface to run exchange functions on Binance USDT Futures."""
 
-    def __init__(self) -> None:
+    def __init__(self, testnet: bool = False) -> None:
+        """
+        :param testnet: whether to use the testnet version of the exchange.
+        """
+
         name = "binance"
         base_url = "https://fapi.binance.com"
+        if testnet:
+            base_url = "https://testnet.binancefuture.com"
 
-        super().__init__(name, base_url)
+        super().__init__(name, testnet, base_url)
 
     @classmethod
     def get_config_params(cls) -> Dict:

--- a/afang/exchanges/binance.py
+++ b/afang/exchanges/binance.py
@@ -69,7 +69,7 @@ class BinanceExchange(IsExchange):
         symbol: str,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
-        timeframe: Optional[Timeframe] = Timeframe.M1,
+        timeframe: Timeframe = Timeframe.M1,
     ) -> Optional[List[Candle]]:
         """Fetch candlestick bars for a particular symbol from the Binance
         exchange. If start_time and end_time are not sent, the most recent

--- a/afang/exchanges/dydx.py
+++ b/afang/exchanges/dydx.py
@@ -26,13 +26,17 @@ class TimeframeMapping(Enum):
 class DyDxExchange(IsExchange):
     """Interface to run exchange functions on DyDx Futures."""
 
-    def __init__(self) -> None:
-        """Initialize DyDxClient class."""
+    def __init__(self, testnet: bool = False) -> None:
+        """
+        :param testnet: whether to use the testnet version of the exchange.
+        """
 
         name = "dydx"
         base_url = "https://api.dydx.exchange"
+        if testnet:
+            base_url = "https://api.stage.dydx.exchange"
 
-        super().__init__(name, base_url)
+        super().__init__(name, testnet, base_url)
 
     @classmethod
     def get_config_params(cls) -> Dict:

--- a/afang/exchanges/dydx.py
+++ b/afang/exchanges/dydx.py
@@ -76,7 +76,7 @@ class DyDxExchange(IsExchange):
         symbol: str,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
-        timeframe: Optional[Timeframe] = Timeframe.M1,
+        timeframe: Timeframe = Timeframe.M1,
     ) -> Optional[List[Candle]]:
         """Fetch candlestick bars for a particular symbol from the DyDx
         exchange. If start_time and end_time are not sent, the most recent

--- a/afang/exchanges/is_exchange.py
+++ b/afang/exchanges/is_exchange.py
@@ -14,8 +14,9 @@ class IsExchange(ABC):
     """Base interface for any supported exchange."""
 
     @abstractmethod
-    def __init__(self, name: str, base_url: str) -> None:
+    def __init__(self, name: str, testnet: bool, base_url: str) -> None:
         self.name = name
+        self.testnet = testnet
         self._base_url = base_url
         self.symbols = self._get_symbols()
 

--- a/afang/exchanges/is_exchange.py
+++ b/afang/exchanges/is_exchange.py
@@ -101,7 +101,7 @@ class IsExchange(ABC):
         symbol: str,
         start_time: Optional[int] = None,
         end_time: Optional[int] = None,
-        timeframe: Optional[Timeframe] = Timeframe.M1,
+        timeframe: Timeframe = Timeframe.M1,
     ) -> Optional[List[Candle]]:
         """Fetch candlestick bars for a particular symbol from the exchange. If
         start_time and end_time are not provided, the most recent klines are

--- a/afang/main.py
+++ b/afang/main.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import operator
 import sys
@@ -12,19 +13,19 @@ from afang.strategies.optimizer import StrategyOptimizer
 logger = logging.getLogger(__name__)
 
 
-def get_exchange_client(exchange_name: str) -> Optional[IsExchange]:
+def get_exchange_client(parsed_args: argparse.Namespace) -> Optional[IsExchange]:
     """Get the proper exchange client given the exchange's name.
 
-    :param exchange_name: name of the exchange client.
+    :param parsed_args: arguments parsed from the CLI.
 
     :return: Optional[IsExchange]
     """
 
     exchange: Optional[IsExchange] = None
-    if exchange_name == "binance":
-        exchange = BinanceExchange()
-    elif exchange_name == "dydx":
-        exchange = DyDxExchange()
+    if parsed_args.exchange == "binance":
+        exchange = BinanceExchange(testnet=parsed_args.testnet)
+    elif parsed_args.exchange == "dydx":
+        exchange = DyDxExchange(testnet=parsed_args.testnet)
 
     return exchange
 
@@ -58,7 +59,7 @@ def main(args):
     parsed_args = parse_args(args)
 
     # Get the exchange client.
-    exchange = get_exchange_client(parsed_args.exchange)
+    exchange = get_exchange_client(parsed_args)
     if not exchange:
         logger.warning("Unknown exchange provided: %s", parsed_args.exchange)
         return

--- a/afang/strategies/backtester.py
+++ b/afang/strategies/backtester.py
@@ -358,7 +358,7 @@ class Backtester(ABC):
             self.strategy_name,
         )
 
-        ohlcv_db = OHLCVDatabase(self.exchange.name, symbol)
+        ohlcv_db = OHLCVDatabase(self.exchange, symbol)
         ohlcv_data = ohlcv_db.get_data(
             symbol, self.backtest_from_time, self.backtest_to_time
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def delete_optimization_records(optimization_root_dir) -> Generator:
 def dummy_is_exchange() -> IsExchange:
     class Dummy(IsExchange):
         def __init__(self, name: str, base_url: str) -> None:
-            super().__init__(name, base_url)
+            super().__init__(name, False, base_url)
 
         @classmethod
         def get_config_params(cls) -> Dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,7 @@ def dummy_is_exchange() -> IsExchange:
             symbol: str,
             start_time: Optional[int] = None,
             end_time: Optional[int] = None,
-            timeframe: Optional[Timeframe] = Timeframe.M1,
+            timeframe: Timeframe = Timeframe.M1,
         ) -> Optional[List[Candle]]:
             return super().get_historical_candles(
                 symbol, start_time, end_time, timeframe

--- a/tests/database/backtest_data_collector_test.py
+++ b/tests/database/backtest_data_collector_test.py
@@ -45,7 +45,7 @@ def test_fetch_initial_data(
         "afang.database.backtest_data_collector.OHLCVDatabase.write_data"
     )
 
-    test_ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+    test_ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     test_ohlcv_db.create_dataset("test_symbol")
     return_val = fetch_initial_data(dummy_is_exchange, "test_symbol", test_ohlcv_db)
 
@@ -83,7 +83,7 @@ def test_fetch_most_recent_data(
         "afang.database.backtest_data_collector.OHLCVDatabase.write_data"
     )
 
-    test_ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+    test_ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     test_ohlcv_db.create_dataset("test_symbol")
     return_val = fetch_most_recent_data(
         dummy_is_exchange, "test_symbol", test_ohlcv_db, 0, 1, 1
@@ -123,7 +123,7 @@ def test_fetch_older_data(
         "afang.database.backtest_data_collector.OHLCVDatabase.write_data"
     )
 
-    test_ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+    test_ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     test_ohlcv_db.create_dataset("test_symbol")
     return_val = fetch_older_data(
         dummy_is_exchange, "test_symbol", test_ohlcv_db, 5, 1, 1

--- a/tests/database/ohlcv_database_test.py
+++ b/tests/database/ohlcv_database_test.py
@@ -45,6 +45,25 @@ def test_symbol_database_creation(ohlcv_root_db_dir, dummy_is_exchange) -> None:
         is True
     )
 
+    # test that a testnet database can be created if it doesn't exist yet.
+    dummy_is_exchange.testnet = True
+    OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
+    assert os.path.exists(f"{ohlcv_root_db_dir}/test_exchange-testnet") is True
+    assert (
+        os.path.exists(f"{ohlcv_root_db_dir}/test_exchange-testnet/test_symbol.h5")
+        is True
+    )
+
+    # test that a new symbol database can be created under the same testnet exchange.
+    OHLCVDatabase(dummy_is_exchange, "another_test_symbol", ohlcv_root_db_dir)
+    assert os.path.exists(f"{ohlcv_root_db_dir}/test_exchange-testnet") is True
+    assert (
+        os.path.exists(
+            f"{ohlcv_root_db_dir}/test_exchange-testnet/another_test_symbol.h5"
+        )
+        is True
+    )
+
 
 def test_symbol_dataset_creation(ohlcv_root_db_dir, dummy_is_exchange) -> None:
     ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)

--- a/tests/database/ohlcv_database_test.py
+++ b/tests/database/ohlcv_database_test.py
@@ -31,14 +31,14 @@ def ohlcv_write_data() -> List[Candle]:
     ]
 
 
-def test_symbol_database_creation(ohlcv_root_db_dir) -> None:
+def test_symbol_database_creation(ohlcv_root_db_dir, dummy_is_exchange) -> None:
     # test that database is created if it doesn't yet exist.
-    OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+    OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     assert os.path.exists(f"{ohlcv_root_db_dir}/test_exchange") is True
     assert os.path.exists(f"{ohlcv_root_db_dir}/test_exchange/test_symbol.h5") is True
 
     # test that a new symbol database can be created under the same exchange.
-    OHLCVDatabase("test_exchange", "another_test_symbol", ohlcv_root_db_dir)
+    OHLCVDatabase(dummy_is_exchange, "another_test_symbol", ohlcv_root_db_dir)
     assert os.path.exists(f"{ohlcv_root_db_dir}/test_exchange") is True
     assert (
         os.path.exists(f"{ohlcv_root_db_dir}/test_exchange/another_test_symbol.h5")
@@ -46,16 +46,18 @@ def test_symbol_database_creation(ohlcv_root_db_dir) -> None:
     )
 
 
-def test_symbol_dataset_creation(ohlcv_root_db_dir) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_symbol_dataset_creation(ohlcv_root_db_dir, dummy_is_exchange) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     assert "test_symbol" not in ohlcv_db.hf.keys()
 
     ohlcv_db.create_dataset("test_symbol")
     assert "test_symbol" in ohlcv_db.hf.keys()
 
 
-def test_write_to_non_existent_dataset(ohlcv_root_db_dir, caplog) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_write_to_non_existent_dataset(
+    ohlcv_root_db_dir, dummy_is_exchange, caplog
+) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     ohlcv_db.write_data("non_existent_symbol", [])
 
     assert caplog.records[0].levelname == "WARNING"
@@ -75,6 +77,7 @@ def test_write_to_non_existent_dataset(ohlcv_root_db_dir, caplog) -> None:
 def test_write_to_dataset(
     mocker,
     ohlcv_root_db_dir,
+    dummy_is_exchange,
     caplog,
     ohlcv_write_data,
     min_ts,
@@ -84,7 +87,7 @@ def test_write_to_dataset(
     expected_data_len,
 ) -> None:
     # set up dataset for a symbol and write initial data into the dataset.
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     ohlcv_db.create_dataset("test_symbol")
     ohlcv_db.write_data("test_symbol", ohlcv_write_data)
 
@@ -106,13 +109,15 @@ def test_write_to_dataset(
         assert expected_log_text in caplog.text
 
 
-def test_get_min_max_timestamp_no_dataset(ohlcv_root_db_dir) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_get_min_max_timestamp_no_dataset(ohlcv_root_db_dir, dummy_is_exchange) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     assert ohlcv_db.get_min_max_timestamp("test_symbol") == (None, None)
 
 
-def test_get_min_max_timestamp_empty_dataset(ohlcv_root_db_dir) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_get_min_max_timestamp_empty_dataset(
+    ohlcv_root_db_dir, dummy_is_exchange
+) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     ohlcv_db.create_dataset("test_symbol")
     assert ohlcv_db.get_min_max_timestamp("test_symbol") == (None, None)
 
@@ -135,28 +140,30 @@ def test_get_min_max_timestamp_empty_dataset(ohlcv_root_db_dir) -> None:
         ),
     ],
 )
-def test_get_min_max_timestamp(ohlcv_root_db_dir, data, min_ts, max_ts) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_get_min_max_timestamp(
+    ohlcv_root_db_dir, dummy_is_exchange, data, min_ts, max_ts
+) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     ohlcv_db.create_dataset("test_symbol")
     ohlcv_db.write_data("test_symbol", data)
 
     assert ohlcv_db.get_min_max_timestamp("test_symbol") == (min_ts, max_ts)
 
 
-def test_get_data_no_dataset(ohlcv_root_db_dir) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_get_data_no_dataset(ohlcv_root_db_dir, dummy_is_exchange) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     data = ohlcv_db.get_data("test_symbol", 0, 100)
     assert data is None
 
 
-def test_get_data_empty_dataset(ohlcv_root_db_dir) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_get_data_empty_dataset(ohlcv_root_db_dir, dummy_is_exchange) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     ohlcv_db.create_dataset("test_symbol")
     data = ohlcv_db.get_data("test_symbol", 0, 100)
     assert data is None
 
 
-def test_get_data(ohlcv_root_db_dir, caplog) -> None:
+def test_get_data(ohlcv_root_db_dir, dummy_is_exchange, caplog) -> None:
     ohlcv_data: List[Candle] = [
         Candle(5, 40.2, 92.5, 8.5, 12.2, 190.5),
         Candle(1, 10.2, 12.5, 9.5, 14.2, 120.5),
@@ -165,7 +172,7 @@ def test_get_data(ohlcv_root_db_dir, caplog) -> None:
         Candle(3, 60.2, 62.5, 2.5, 18.2, 150.5),
     ]
 
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     ohlcv_db.create_dataset("test_symbol")
     ohlcv_db.write_data("test_symbol", ohlcv_data)
     data = ohlcv_db.get_data("test_symbol", 2, 4)
@@ -189,16 +196,16 @@ def test_get_data(ohlcv_root_db_dir, caplog) -> None:
     assert_frame_equal(data, expected_data_df, check_dtype=True)
 
 
-def test_is_data_valid_no_dataset(ohlcv_root_db_dir, caplog) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_is_data_valid_no_dataset(ohlcv_root_db_dir, dummy_is_exchange, caplog) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     is_valid = ohlcv_db.is_dataset_valid("test_symbol")
 
     assert "no dataset exists for symbol in database" in caplog.text
     assert not is_valid
 
 
-def test_is_data_valid_empty_dataset(ohlcv_root_db_dir) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_is_data_valid_empty_dataset(ohlcv_root_db_dir, dummy_is_exchange) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     ohlcv_db.create_dataset("test_symbol")
     is_valid = ohlcv_db.is_dataset_valid("test_symbol")
 
@@ -228,8 +235,10 @@ def test_is_data_valid_empty_dataset(ohlcv_root_db_dir) -> None:
         ),
     ],
 )
-def test_is_data_valid(ohlcv_root_db_dir, caplog, data, expect_is_valid) -> None:
-    ohlcv_db = OHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+def test_is_data_valid(
+    ohlcv_root_db_dir, dummy_is_exchange, caplog, data, expect_is_valid
+) -> None:
+    ohlcv_db = OHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
     ohlcv_db.create_dataset("test_symbol")
     ohlcv_db.write_data("test_symbol", data)
     is_valid = ohlcv_db.is_dataset_valid("test_symbol")

--- a/tests/exchanges/binance_test.py
+++ b/tests/exchanges/binance_test.py
@@ -19,12 +19,17 @@ def test_binance_exchange_init(mocker) -> None:
 
     binance_exchange = BinanceExchange()
     assert binance_exchange.name == "binance"
+    assert binance_exchange.testnet is False
     assert binance_exchange._base_url == "https://fapi.binance.com"
     assert binance_exchange.symbols == ["BTCUSDT", "ETHUSDT"]
     assert binance_exchange.get_config_params() == {
         "query_limit": 1.1,
         "write_limit": 10000,
     }
+
+    binance_exchange_testnet = BinanceExchange(testnet=True)
+    assert binance_exchange_testnet.testnet is True
+    assert binance_exchange_testnet._base_url == "https://testnet.binancefuture.com"
 
 
 @pytest.mark.parametrize(

--- a/tests/exchanges/dydx_test.py
+++ b/tests/exchanges/dydx_test.py
@@ -19,12 +19,17 @@ def test_dydx_exchange_init(mocker) -> None:
 
     dydx_exchange = DyDxExchange()
     assert dydx_exchange.name == "dydx"
+    assert dydx_exchange.testnet is False
     assert dydx_exchange._base_url == "https://api.dydx.exchange"
     assert dydx_exchange.symbols == ["BTCUSDT", "ETHUSDT"]
     assert dydx_exchange.get_config_params() == {
         "query_limit": 0.2,
         "write_limit": 20000,
     }
+
+    dydx_exchange_testnet = DyDxExchange(testnet=True)
+    assert dydx_exchange_testnet.testnet is True
+    assert dydx_exchange_testnet._base_url == "https://api.stage.dydx.exchange"
 
 
 @pytest.mark.parametrize(

--- a/tests/strategies/backtester_test.py
+++ b/tests/strategies/backtester_test.py
@@ -44,7 +44,7 @@ def ohlcv_df() -> pd.DataFrame:
 
 
 @pytest.fixture
-def ohlcv_db(ohlcv_root_db_dir, ohlcv_df) -> OHLCVDatabase:
+def ohlcv_db(ohlcv_root_db_dir, dummy_is_exchange, ohlcv_df) -> OHLCVDatabase:
     class DummyOHLCVDatabase(OHLCVDatabase):
         def get_data(
             self, symbol: str, from_time: int, to_time: int
@@ -73,7 +73,7 @@ def ohlcv_db(ohlcv_root_db_dir, ohlcv_df) -> OHLCVDatabase:
                 ],
             )
 
-    return DummyOHLCVDatabase("test_exchange", "test_symbol", ohlcv_root_db_dir)
+    return DummyOHLCVDatabase(dummy_is_exchange, "test_symbol", ohlcv_root_db_dir)
 
 
 def test_generate_uuid(dummy_is_strategy) -> None:


### PR DESCRIPTION
### Description

This PR adds testnet functionality to allow users to be able to backtest and trade strategies on exchange testnets.

### Changelog

- Added a testnet param to exchange classes.
- Added testnet handling in the `OHLCV` database.

### Checklist

- [x] This change has been unit tested.
