### PR TITLE
Remove mode from exchanges

### DIFF
--- a/afang/exchanges/binance.py
+++ b/afang/exchanges/binance.py
@@ -21,7 +21,7 @@ from afang.exchanges.models import (
     Symbol,
     SymbolBalance,
 )
-from afang.models import Mode, Timeframe
+from afang.models import Timeframe
 from afang.utils.util import get_float_precision
 
 load_dotenv()
@@ -45,7 +45,7 @@ class TimeframeMapping(ExchangeTimeframeMapping):
 class BinanceExchange(IsExchange):
     """Interface to run exchange functions on Binance USDT Futures."""
 
-    def __init__(self, mode: Optional[Mode] = None, testnet: bool = False) -> None:
+    def __init__(self, testnet: bool = False) -> None:
         """
         :param testnet: whether to use the testnet version of the exchange.
         """
@@ -57,7 +57,7 @@ class BinanceExchange(IsExchange):
             base_url = "https://testnet.binancefuture.com"
             wss_url = "wss://stream.binancefuture.com/ws"
 
-        super().__init__(name, mode, testnet, base_url, wss_url)
+        super().__init__(name, testnet, base_url, wss_url)
 
         # Binance exchange environment variables.
         self._API_KEY = os.environ.get("BINANCE_API_KEY")

--- a/afang/exchanges/is_exchange.py
+++ b/afang/exchanges/is_exchange.py
@@ -17,7 +17,7 @@ from afang.exchanges.models import (
     Symbol,
     SymbolBalance,
 )
-from afang.models import Mode, Timeframe
+from afang.models import Timeframe
 
 logger = logging.getLogger(__name__)
 
@@ -36,14 +36,12 @@ class IsExchange(ABC):
     def __init__(
         self,
         name: str,
-        mode: Optional[Mode],
         testnet: bool,
         base_url: str,
         wss_url: str,
     ) -> None:
         self.name = name
         self.display_name = name + "-testnet" if testnet else name
-        self.mode = mode
         self.testnet = testnet
         self._base_url = base_url
         self._wss_url = wss_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from afang.exchanges.models import (
     OrderType,
     Symbol,
 )
-from afang.models import Mode, Timeframe
+from afang.models import Timeframe
 from afang.strategies.is_strategy import IsStrategy
 from afang.strategies.models import TradeLevels
 from afang.strategies.optimizer import StrategyOptimizer
@@ -66,10 +66,8 @@ def delete_optimization_records(optimization_root_dir) -> Generator:
 @pytest.fixture
 def dummy_is_exchange() -> IsExchange:
     class Dummy(IsExchange):
-        def __init__(
-            self, name: str, mode: Optional[Mode], base_url: str, wss_url: str
-        ) -> None:
-            super().__init__(name, mode, False, base_url, wss_url)
+        def __init__(self, name: str, base_url: str, wss_url: str) -> None:
+            super().__init__(name, False, base_url, wss_url)
 
         @classmethod
         def get_config_params(cls) -> Dict:
@@ -127,7 +125,6 @@ def dummy_is_exchange() -> IsExchange:
 
     return Dummy(
         name="test_exchange",
-        mode=None,
         base_url="https://dummy.com",
         wss_url="wss://dummy.com/ws",
     )

--- a/tests/exchanges/binance_test.py
+++ b/tests/exchanges/binance_test.py
@@ -14,7 +14,7 @@ from afang.exchanges.models import (
     Symbol,
     SymbolBalance,
 )
-from afang.models import Mode, Timeframe
+from afang.models import Timeframe
 
 
 def test_binance_exchange_init(mocker) -> None:
@@ -29,7 +29,6 @@ def test_binance_exchange_init(mocker) -> None:
 
     binance_exchange = BinanceExchange()
     assert binance_exchange.name == "binance"
-    assert binance_exchange.mode is None
     assert binance_exchange.display_name == "binance"
     assert binance_exchange.testnet is False
     assert binance_exchange._base_url == "https://fapi.binance.com"
@@ -41,14 +40,10 @@ def test_binance_exchange_init(mocker) -> None:
     }
 
     binance_exchange_testnet = BinanceExchange(testnet=True)
-    assert binance_exchange_testnet.mode is None
     assert binance_exchange_testnet.display_name == "binance-testnet"
     assert binance_exchange_testnet.testnet is True
     assert binance_exchange_testnet._base_url == "https://testnet.binancefuture.com"
     assert binance_exchange_testnet._wss_url == "wss://stream.binancefuture.com/ws"
-
-    binance_exchange_data_mode = BinanceExchange(mode=Mode.data)
-    assert binance_exchange_data_mode.mode == Mode.data
 
 
 @pytest.mark.parametrize(

--- a/tests/exchanges/is_exchange_test.py
+++ b/tests/exchanges/is_exchange_test.py
@@ -13,7 +13,6 @@ def test_is_exchange_initialization(dummy_is_exchange) -> None:
     assert dummy_is_exchange.display_name == "test_exchange"
     assert dummy_is_exchange._base_url == "https://dummy.com"
     assert dummy_is_exchange._wss_url == "wss://dummy.com/ws"
-    assert dummy_is_exchange.mode is None
     assert dummy_is_exchange.exchange_symbols == dict()
     assert dummy_is_exchange.get_historical_candles("test_symbol", 0, 100) is None
     assert dummy_is_exchange.get_config_params() == {


### PR DESCRIPTION
### Description

This PR removes application `mode` from exchange classes to improve modularity.

### Changelog
- Remove `mode` from exchange classes.

### Checklist

- [X] This change has been unit tested.
