### PR TITLE
Add make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ setup: $(VENV)/bin/activate
 run: $(VENV)/bin/activate
 	./$(PYTHON) -m afang $(ARGS)
 
+lint:
+	pre-commit run --all-files
+
 test: $(VENV)/bin/activate
 	./$(PYTHON) -m pytest --cov=afang/ tests/
 
@@ -26,4 +29,4 @@ clean:
 	rm -rf $(VENV)/
 	find . -type f -name '*.pyc' -delete
 
-.PHONY: all setup run test clean
+.PHONY: all setup run lint test clean


### PR DESCRIPTION
### Description

This PR adds `make lint` to Makefile.

### Changelog

- Add `make lint` to run `pre-commit` hooks.

### Checklist

- [ ] This change has been unit tested.
