### PR TITLE
Add threadpool to backtest

### DIFF
--- a/tests/strategies/backtester_test.py
+++ b/tests/strategies/backtester_test.py
@@ -449,6 +449,17 @@ def test_run_symbol_backtest(
     assert len(dummy_is_strategy.backtest_data["test_symbol"].index) == 2
 
 
+def test_run_symbol_backtest_symbol_not_in_exchange(
+    caplog, dummy_is_exchange, dummy_is_strategy
+) -> None:
+    dummy_is_strategy.timeframe = "5m"
+    dummy_is_strategy.exchange = dummy_is_exchange
+    dummy_is_strategy.run_symbol_backtest("test_symbol")
+
+    assert caplog.records[-1].levelname == "ERROR"
+    assert "provided symbol not present in the exchange" in caplog.text
+
+
 def test_run_symbol_backtest_no_ohlcv_data(
     mocker, caplog, dummy_is_strategy, dummy_is_exchange, ohlcv_db_no_data
 ) -> None:


### PR DESCRIPTION
### Description

Add threadpool to backtest to speed up backtesting for multiple symbols.

### Changelog

- Added threadpool to speed up backtesting for multiple symbols.
- Added functionality to allow long and short positions to be opened during backtest at the same time but cannot be closed at the same candle at which they were opened.

### Checklist

- [X] This change has been unit tested.
