### PR TITLE
Switch to num open trades

### DIFF
--- a/afang/strategies/SampleStrategy/SampleStrategy.py
+++ b/afang/strategies/SampleStrategy/SampleStrategy.py
@@ -19,7 +19,7 @@ class SampleStrategy(IsStrategy):
         self.max_holding_candles = 192
         self.max_amount_per_trade = 1000
         self.unstable_indicator_values = 300
-        self.allow_multiple_open_positions = False
+        self.max_open_positions = 1
 
     def plot_backtest_indicators(self) -> Dict:
         """Get the indicators to plot on the backtest analysis dashboard.

--- a/afang/strategies/backtester.py
+++ b/afang/strategies/backtester.py
@@ -540,9 +540,7 @@ class Backtester(Root):
             if should_open_new_position:
                 # only open a position if multiple open positions are allowed or
                 # there is no open position.
-                if self.allow_multiple_open_positions or not len(
-                    self.open_symbol_positions[symbol]
-                ):
+                if len(self.open_symbol_positions[symbol]) < self.max_open_positions:
                     trade_levels = self.generate_trade_levels(
                         symbol, row, trade_signal_direction=new_position_direction
                     )

--- a/afang/strategies/root.py
+++ b/afang/strategies/root.py
@@ -47,8 +47,8 @@ class Root:
         # maximum amount to invest per trade.
         # If `None`, there will be no maximum amount to invest per trade.
         self.max_amount_per_trade: Optional[int] = None
-        # Whether to allow for multiple open positions per symbol at a time.
-        self.allow_multiple_open_positions: bool = True
+        # Sets how many trade positions can be open at any given time.
+        self.max_open_positions: int = 1
         # strategy configuration parameters i.e. contents of strategy `config.yaml`.
         self.config: Dict = dict()
         # test account initial balance - will be constantly updated to match current account balance.

--- a/afang/strategies/trader.py
+++ b/afang/strategies/trader.py
@@ -1498,7 +1498,7 @@ class Trader(Root):
         if should_open_new_position:
             # only open a position if multiple open positions are allowed or
             # there is no open position.
-            if self.allow_multiple_open_positions or not len(symbol_open_positions):
+            if len(symbol_open_positions) < self.max_open_positions:
                 trade_levels = self.generate_trade_levels(
                     symbol,
                     current_candle_data,

--- a/tests/strategies/SampleStrategy/SampleStrategy_test.py
+++ b/tests/strategies/SampleStrategy/SampleStrategy_test.py
@@ -100,7 +100,7 @@ def test_sample_strategy_params(sample_strategy) -> None:
     assert sample_strategy.max_holding_candles == 192
     assert sample_strategy.max_amount_per_trade == 1000
     assert sample_strategy.unstable_indicator_values == 300
-    assert not sample_strategy.allow_multiple_open_positions
+    assert sample_strategy.max_open_positions == 1
 
 
 def test_generate_features(sample_strategy, ohlcv_df) -> None:


### PR DESCRIPTION
### Description

Switch to having `max_num_open_trades` rather than allowing an arbitrary max number of open trades.

### Changelog

- Switch to having `max_num_open_trades`.

### Checklist

- [X] This change has been unit tested.
