### PR TITLE
Add progress visuals to trader

### DIFF
--- a/afang/strategies/root.py
+++ b/afang/strategies/root.py
@@ -2,6 +2,7 @@ import logging
 import queue
 import threading
 from collections import defaultdict
+from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
 import peewee
@@ -57,6 +58,14 @@ class Root:
         self.open_order_type: Literal[
             OrderType.LIMIT, OrderType.MARKET
         ] = OrderType.MARKET
+        # trades' database instance.
+        self.trades_database: Optional[TradesDatabase] = None
+        # Order type to be used to place take profit orders.
+        self.take_profit_order_type: Literal[
+            OrderType.LIMIT, OrderType.MARKET
+        ] = OrderType.MARKET
+        # Order type to be used to place stop loss orders.
+        self.stop_loss_order_type: Literal[OrderType.MARKET] = OrderType.MARKET
 
         # --Unique to Backtester (not in Trader)
         self.backtest_to_time: Optional[int] = None
@@ -73,16 +82,12 @@ class Root:
         self.demo_mode_exchange_orders: Dict[str, List[ExchangeOrder]] = defaultdict(
             list
         )
-        # trades' database instance.
-        self.trades_database: Optional[TradesDatabase] = None
+        # all symbols that have successfully gone through the trading loop within a specified TTL.
+        self.actively_trading_symbols: set = set()
+        # last time that all actively traded symbols was reported.
+        self.last_report_time: datetime = datetime.utcnow()
         # execution queue that will run trader on present symbols FIFO.
         self.trading_execution_queue: queue.Queue = queue.Queue()
-        # Order type to be used to place take profit orders.
-        self.take_profit_order_type: Literal[
-            OrderType.LIMIT, OrderType.MARKET
-        ] = OrderType.MARKET
-        # Order type to be used to place stop loss orders.
-        self.stop_loss_order_type: Literal[OrderType.MARKET] = OrderType.MARKET
         # Orders will only be placed if they enter the order book. May not be supported by all exchanges.
         self.post_only_orders: bool = False
         # Highest accepted fee for a trade on the dYdX exchange. Note that this is specific to dYdX.

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,7 @@ TA-Lib==0.4.26
 toml==0.10.2
 tomli==2.0.1
 toolz==0.12.0
+tqdm==4.65.0
 typing_extensions==4.6.3
 urllib3==1.26.16
 varint==1.0.2

--- a/tests/strategies/trader_test.py
+++ b/tests/strategies/trader_test.py
@@ -859,6 +859,7 @@ def test_run_symbol_trader(
 def test_run_trader(
     mocker, dummy_is_strategy, dummy_is_exchange, trades_db_filepath
 ) -> None:
+    mocker.patch.object(Trader, "report_actively_trading_symbols")
     mocked_setup_exchange_for_trading = mocker.patch.object(
         IsExchange, "setup_exchange_for_trading"
     )
@@ -873,6 +874,18 @@ def test_run_trader(
 
     assert mocked_setup_exchange_for_trading.called
     assert mocked_change_initial_leverage.called
+
+
+def test_report_actively_trading_symbols(
+    dummy_is_strategy, dummy_is_exchange, caplog
+) -> None:
+    dummy_is_strategy.last_report_time = datetime.datetime(year=2000, month=1, day=1)
+    dummy_is_strategy.actively_trading_symbols = {"ETH-USD"}
+
+    dummy_is_strategy.report_actively_trading_symbols(ttl_minutes=5, run_forever=False)
+
+    assert caplog.records[-1].levelname == "INFO"
+    assert "test_exchange: actively trading: ETH-USD" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Add progress visuals to trader to make it apparent that computation is well underway.

### Changelog

- Add `tqdm` progress bar to show completion of each symbol backtest.
- Add progress log to trader to notify user of actively traded symbols within a given `ttl`.

### Checklist

- [X] This change has been unit tested.
